### PR TITLE
Update devcontainer.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,3 +11,18 @@ xhost +local:root > /dev/null  # Allows GUI in dev container to work
 ```
 
 if you want to open any GUI programs from inside dev-containers.
+
+
+## Notes
+
+In ``devcontainer.json``:
+
+* ``mounts``
+  * ``source=/tmp/.X11-unix,target=/tmp/.X11-unix,type=bind,consistency=cached`` allows GUI programs to work. This is necessary for
+  RQt to work.
+* ``runArgs``
+  * ``--device=/dev/video0:/dev/video0:mwr`` allows the container to access the host's webcam. This is necessary for nodes such as ``usb_cam``or ``v4l2_camera``.
+  * ``--network=host`` allows the container to share the host’s networking namespace, and the container does not get its own IP-address allocated.
+  This is necessary for nodes inside the docker container to communicate to
+  nodes on the same network but on a different machine.
+  * ``--device=/dev/dri:/dev/dri`` allows the container to access the host's GPU. This is needed to run ``rviz2``.

--- a/foxy/foxy-desktop/.devcontainer/devcontainer.json
+++ b/foxy/foxy-desktop/.devcontainer/devcontainer.json
@@ -1,12 +1,16 @@
 {
   "dockerFile": "Dockerfile",
   "containerEnv": {
-    "DISPLAY": "unix:0"
+    "DISPLAY": "unix:0",
+    "NVIDIA_VISIBLE_DEVICES": "all",
+    "NVIDIA_DRIVER_CAPABILITIES": "all"
   },
   "mounts": [
     "source=/tmp/.X11-unix,target=/tmp/.X11-unix,type=bind,consistency=cached"
   ],
   "runArgs": [
-    "--device=/dev/video0:/dev/video0:mwr"
+    "--device=/dev/video0:/dev/video0:mwr",
+    "--network=host",
+    "--device=/dev/dri:/dev/dri"
   ]
 }

--- a/foxy/foxy-desktop/.devcontainer/devcontainer.json
+++ b/foxy/foxy-desktop/.devcontainer/devcontainer.json
@@ -1,9 +1,7 @@
 {
   "dockerFile": "Dockerfile",
   "containerEnv": {
-    "DISPLAY": "unix:0",
-    "NVIDIA_VISIBLE_DEVICES": "all",
-    "NVIDIA_DRIVER_CAPABILITIES": "all"
+    "DISPLAY": "unix:0"
   },
   "mounts": [
     "source=/tmp/.X11-unix,target=/tmp/.X11-unix,type=bind,consistency=cached"

--- a/foxy/foxy-ros-base/.devcontainer/devcontainer.json
+++ b/foxy/foxy-ros-base/.devcontainer/devcontainer.json
@@ -7,6 +7,8 @@
     "source=/tmp/.X11-unix,target=/tmp/.X11-unix,type=bind,consistency=cached"
   ],
   "runArgs": [
-    "--device=/dev/video0:/dev/video0:mwr"
+    "--device=/dev/video0:/dev/video0:mwr",
+    "--network=host",
+    "--device=/dev/dri:/dev/dri"
   ]
 }

--- a/foxy/foxy-ros-core/.devcontainer/devcontainer.json
+++ b/foxy/foxy-ros-core/.devcontainer/devcontainer.json
@@ -7,6 +7,8 @@
     "source=/tmp/.X11-unix,target=/tmp/.X11-unix,type=bind,consistency=cached"
   ],
   "runArgs": [
-    "--device=/dev/video0:/dev/video0:mwr"
+    "--device=/dev/video0:/dev/video0:mwr",
+    "--network=host",
+    "--device=/dev/dri:/dev/dri"
   ]
 }

--- a/galactic/galactic-desktop/.devcontainer/devcontainer.json
+++ b/galactic/galactic-desktop/.devcontainer/devcontainer.json
@@ -7,6 +7,8 @@
     "source=/tmp/.X11-unix,target=/tmp/.X11-unix,type=bind,consistency=cached"
   ],
   "runArgs": [
-    "--device=/dev/video0:/dev/video0:mwr"
+    "--device=/dev/video0:/dev/video0:mwr",
+    "--network=host",
+    "--device=/dev/dri:/dev/dri"
   ]
 }

--- a/galactic/galactic-ros-base/.devcontainer/devcontainer.json
+++ b/galactic/galactic-ros-base/.devcontainer/devcontainer.json
@@ -7,6 +7,8 @@
     "source=/tmp/.X11-unix,target=/tmp/.X11-unix,type=bind,consistency=cached"
   ],
   "runArgs": [
-    "--device=/dev/video0:/dev/video0:mwr"
+    "--device=/dev/video0:/dev/video0:mwr",
+    "--network=host",
+    "--device=/dev/dri:/dev/dri"
   ]
 }

--- a/galactic/galactic-ros-core/.devcontainer/devcontainer.json
+++ b/galactic/galactic-ros-core/.devcontainer/devcontainer.json
@@ -7,6 +7,8 @@
     "source=/tmp/.X11-unix,target=/tmp/.X11-unix,type=bind,consistency=cached"
   ],
   "runArgs": [
-    "--device=/dev/video0:/dev/video0:mwr"
+    "--device=/dev/video0:/dev/video0:mwr",
+    "--network=host",
+    "--device=/dev/dri:/dev/dri"
   ]
 }

--- a/humble/humble-desktop-full/.devcontainer/devcontainer.json
+++ b/humble/humble-desktop-full/.devcontainer/devcontainer.json
@@ -7,6 +7,8 @@
     "source=/tmp/.X11-unix,target=/tmp/.X11-unix,type=bind,consistency=cached"
   ],
   "runArgs": [
-    "--device=/dev/video0:/dev/video0:mwr"
+    "--device=/dev/video0:/dev/video0:mwr",
+    "--network=host",
+    "--device=/dev/dri:/dev/dri"
   ]
 }

--- a/humble/humble-desktop/.devcontainer/devcontainer.json
+++ b/humble/humble-desktop/.devcontainer/devcontainer.json
@@ -7,6 +7,8 @@
     "source=/tmp/.X11-unix,target=/tmp/.X11-unix,type=bind,consistency=cached"
   ],
   "runArgs": [
-    "--device=/dev/video0:/dev/video0:mwr"
+    "--device=/dev/video0:/dev/video0:mwr",
+    "--network=host",
+    "--device=/dev/dri:/dev/dri"
   ]
 }

--- a/humble/humble-ros-base/.devcontainer/devcontainer.json
+++ b/humble/humble-ros-base/.devcontainer/devcontainer.json
@@ -7,6 +7,8 @@
     "source=/tmp/.X11-unix,target=/tmp/.X11-unix,type=bind,consistency=cached"
   ],
   "runArgs": [
-    "--device=/dev/video0:/dev/video0:mwr"
+    "--device=/dev/video0:/dev/video0:mwr",
+    "--network=host",
+    "--device=/dev/dri:/dev/dri"
   ]
 }

--- a/humble/humble-ros-core/.devcontainer/devcontainer.json
+++ b/humble/humble-ros-core/.devcontainer/devcontainer.json
@@ -7,6 +7,8 @@
     "source=/tmp/.X11-unix,target=/tmp/.X11-unix,type=bind,consistency=cached"
   ],
   "runArgs": [
-    "--device=/dev/video0:/dev/video0:mwr"
+    "--device=/dev/video0:/dev/video0:mwr",
+    "--network=host",
+    "--device=/dev/dri:/dev/dri"
   ]
 }

--- a/rolling/rolling-desktop-full/.devcontainer/devcontainer.json
+++ b/rolling/rolling-desktop-full/.devcontainer/devcontainer.json
@@ -7,6 +7,8 @@
     "source=/tmp/.X11-unix,target=/tmp/.X11-unix,type=bind,consistency=cached"
   ],
   "runArgs": [
-    "--device=/dev/video0:/dev/video0:mwr"
+    "--device=/dev/video0:/dev/video0:mwr",
+    "--network=host",
+    "--device=/dev/dri:/dev/dri"
   ]
 }

--- a/rolling/rolling-desktop/.devcontainer/devcontainer.json
+++ b/rolling/rolling-desktop/.devcontainer/devcontainer.json
@@ -7,6 +7,8 @@
     "source=/tmp/.X11-unix,target=/tmp/.X11-unix,type=bind,consistency=cached"
   ],
   "runArgs": [
-    "--device=/dev/video0:/dev/video0:mwr"
+    "--device=/dev/video0:/dev/video0:mwr",
+    "--network=host",
+    "--device=/dev/dri:/dev/dri"
   ]
 }

--- a/rolling/rolling-ros-base/.devcontainer/devcontainer.json
+++ b/rolling/rolling-ros-base/.devcontainer/devcontainer.json
@@ -7,6 +7,8 @@
     "source=/tmp/.X11-unix,target=/tmp/.X11-unix,type=bind,consistency=cached"
   ],
   "runArgs": [
-    "--device=/dev/video0:/dev/video0:mwr"
+    "--device=/dev/video0:/dev/video0:mwr",
+    "--network=host",
+    "--device=/dev/dri:/dev/dri"
   ]
 }

--- a/rolling/rolling-ros-core/.devcontainer/devcontainer.json
+++ b/rolling/rolling-ros-core/.devcontainer/devcontainer.json
@@ -7,6 +7,8 @@
     "source=/tmp/.X11-unix,target=/tmp/.X11-unix,type=bind,consistency=cached"
   ],
   "runArgs": [
-    "--device=/dev/video0:/dev/video0:mwr"
+    "--device=/dev/video0:/dev/video0:mwr",
+    "--network=host",
+    "--device=/dev/dri:/dev/dri"
   ]
 }


### PR DESCRIPTION
Changes are explained in the README.md:

> In ``devcontainer.json``:
> 
> * ``mounts``
>   * ``source=/tmp/.X11-unix,target=/tmp/.X11-unix,type=bind,consistency=cached`` allows GUI programs to work. This is necessary for
>   RQt to work.
> * ``runArgs``
>   * ``--device=/dev/video0:/dev/video0:mwr`` allows the container to access the host's webcam. This is necessary for nodes such as ``usb_cam``or ``v4l2_camera``.
>   * ``--network=host`` allows the container to share the host’s networking namespace, and the container does not get its own IP-address allocated.
>   This is necessary for nodes inside the docker container to communicate to
>   nodes on the same network but on a different machine.
>   * ``--device=/dev/dri:/dev/dri`` allows the container to access the host's GPU. This is needed to run ``rviz2``.