### PR TITLE
Don't track all files, and only track some

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+# Ignore everything because all files inside the containers get tracked otherwise, and it's annoying.
+*
+
+# Except these files
+*/!.devcontainer/
+!readme_images/
+!README.md
+!.gitignore


### PR DESCRIPTION
When files are created inside a dev container, it gets picked up by git for dev_containers_ros2, which results in thousands of untracked files.

Add a .gitignore with an exclude pattern so files are excluded by defult.